### PR TITLE
Add support for photos/curated endpoint

### DIFF
--- a/src/Photo.php
+++ b/src/Photo.php
@@ -36,6 +36,24 @@ class Photo extends Endpoint
         return new ArrayObject($photosArray, $photos->getHeaders());
     }
 
+
+    /**
+     * Retrieve a single page from the list of the curated photos (front-page’s photos).
+     * Returns an ArrayObject that contains Photo objects.
+     *
+     * @param  integer $page Page from which the photos need to be retrieve
+     * @param  integer $per_page Number of element in a page
+     * @return ArrayObject of Photos
+     */
+    public static function curated($page = 1, $per_page = 10)
+    {
+        $photos = self::get("photos/curated", ['query' => ['page' => $page, 'per_page' => $per_page]]);
+
+        $photosArray = self::getArray($photos->getBody(), get_called_class());
+
+        return new ArrayObject($photosArray, $photos->getHeaders());
+    }
+
     /**
      * Retrieve all the photos on a specific page depending on search results
      * Returns ArrayObject that contain Photo object.

--- a/tests/PhotoTest.php
+++ b/tests/PhotoTest.php
@@ -39,6 +39,18 @@ class PhotoTest extends BaseTest
         $this->assertEquals(10, $photos->count());
     }
 
+
+    public function testFindCurataedPhotos()
+    {
+        VCR::insertCassette('photos.yml');
+
+        $photos = Unsplash\Photo::curated();
+
+        VCR::eject();
+
+        $this->assertEquals(10, $photos->count());
+    }
+
     public function testSearchPhotos()
     {
         VCR::insertCassette('photos.yml');

--- a/tests/fixtures/photos.yml
+++ b/tests/fixtures/photos.yml
@@ -72,6 +72,43 @@
 },{
     "request": {
         "method": "GET",
+        "url": "https:\/\/api.unsplash.com\/photos/curated?page=1&per_page=10",
+        "headers": {
+            "Host": "api.unsplash.com",
+            "Accept-Encoding": null,
+            "User-Agent": "GuzzleHttp\/6.0.2 curl\/7.38.0 PHP\/5.6.11",
+            "Authorization": "Bearer 582c5d7ebe28bd707751a43c8e22dc5c0a4ba0a60dbe69d520677f47b7cfcc1b",
+            "Accept": null
+        }
+    },
+    "response": {
+        "status": {
+            "http_version": "1.1",
+            "code": "200",
+            "message": "OK"
+        },
+        "headers": {
+            "Access-Control-Allow-Origin": "*",
+            "Access-Control-Request-Method": "*",
+            "Link": "<https:\/\/api.unsplash.com:80\/photos?page=411&per_page=10>; rel=\"last\", <https:\/\/api.unsplash.com:80\/photos?page=2&per_page=10>; rel=\"next\"",
+            "X-Total": "4108",
+            "X-Per-Page": "10",
+            "Cache-Control": "max-age=7200, public",
+            "Content-Type": "application\/json",
+            "Content-Length": "8910",
+            "ETag": "W\/\"bddd2196cd4d959eb6d488ce8af624bc\"",
+            "X-Request-Id": "60649417-8a41-425c-8c1d-f12491cd25c3",
+            "X-RateLimit-Limit": "5000",
+            "X-RateLimit-Remaining": "4996",
+            "X-Runtime": "0.088887",
+            "Connection": "keep-alive",
+            "Server": "thin"
+        },
+        "body": "[{\"id\":\"0sCV8yDw2cQ\",\"user\":{\"id\":\"3iQrFoCMWzs\",\"username\":\"atw\",\"name\":\"Cosmic Timetraveler\",\"links\":{\"self\":\"https:\/\/api.lvh.me:3000\/users\/atw\",\"html\":\"http:\/\/lvh.me:3000\/atw\",\"photos\":\"https:\/\/api.lvh.me:3000\/users\/atw\/photos\"}},\"urls\":{\"regular\":\"https:\/\/ununsplash.imgix.net\/photo-1437021663029-4b6a28719dee?q=75\\u0026fm=jpg\\u0026w=1080\\u0026fit=max\\u0026s=9d9f5a81e741a8f3bfbaceb81c002ec5\",\"small\":\"https:\/\/ununsplash.imgix.net\/photo-1437021663029-4b6a28719dee?q=75\\u0026fm=jpg\\u0026w=400\\u0026fit=max\\u0026s=2463c7a7cb007bb40a09257d6d99e850\",\"thumb\":\"https:\/\/ununsplash.imgix.net\/photo-1437021663029-4b6a28719dee?q=75\\u0026fm=jpg\\u0026w=200\\u0026fit=max\\u0026s=35803ffcb54488d4f4dfb826e9364c07\"},\"links\":{\"self\":\"https:\/\/api.lvh.me:3000\/photos\/0sCV8yDw2cQ\",\"html\":\"http:\/\/lvh.me:3000\/photos\/0sCV8yDw2cQ\",\"download\":\"http:\/\/lvh.me:3000\/photos\/0sCV8yDw2cQ\/download\"}},{\"id\":\"kjsDWQQmadk\",\"user\":{\"id\":\"mNl335fWMM8\",\"username\":\"yamonf16\",\"name\":\"Yamon  Figurs\",\"links\":{\"self\":\"https:\/\/api.lvh.me:3000\/users\/yamonf16\",\"html\":\"http:\/\/lvh.me:3000\/yamonf16\",\"photos\":\"https:\/\/api.lvh.me:3000\/users\/yamonf16\/photos\"}},\"urls\":{\"regular\":\"https:\/\/unsplash.imgix.net\/photo-1437011322766-da2f39ff123b?q=75\\u0026fm=jpg\\u0026w=1080\\u0026fit=max\\u0026s=693c6df37bf32c7fdb15e38a55a1f5cf\",\"small\":\"https:\/\/unsplash.imgix.net\/photo-1437011322766-da2f39ff123b?q=75\\u0026fm=jpg\\u0026w=400\\u0026fit=max\\u0026s=f2da5778738ca14caf0ad5cdae510d1c\",\"thumb\":\"https:\/\/unsplash.imgix.net\/photo-1437011322766-da2f39ff123b?q=75\\u0026fm=jpg\\u0026w=200\\u0026fit=max\\u0026s=24e57a216163480d914f4dc1ed7ec41f\"},\"links\":{\"self\":\"https:\/\/api.lvh.me:3000\/photos\/kjsDWQQmadk\",\"html\":\"http:\/\/lvh.me:3000\/photos\/kjsDWQQmadk\",\"download\":\"http:\/\/lvh.me:3000\/photos\/kjsDWQQmadk\/download\"}},{\"id\":\"HXyYF_XrAuU\",\"user\":{\"id\":\"mNl335fWMM8\",\"username\":\"yamonf16\",\"name\":\"Yamon  Figurs\",\"links\":{\"self\":\"https:\/\/api.lvh.me:3000\/users\/yamonf16\",\"html\":\"http:\/\/lvh.me:3000\/yamonf16\",\"photos\":\"https:\/\/api.lvh.me:3000\/users\/yamonf16\/photos\"}},\"urls\":{\"regular\":\"https:\/\/ununsplash.imgix.net\/photo-1437011165434-0b8d687711aa?q=75\\u0026fm=jpg\\u0026w=1080\\u0026fit=max\\u0026s=aad2b12765854f44b579f19bc62cde85\",\"small\":\"https:\/\/ununsplash.imgix.net\/photo-1437011165434-0b8d687711aa?q=75\\u0026fm=jpg\\u0026w=400\\u0026fit=max\\u0026s=9f80ad107bd9753d64307eb5ed33b9e7\",\"thumb\":\"https:\/\/ununsplash.imgix.net\/photo-1437011165434-0b8d687711aa?q=75\\u0026fm=jpg\\u0026w=200\\u0026fit=max\\u0026s=5cfb7b82e35eaa0558445102a9cd60fa\"},\"links\":{\"self\":\"https:\/\/api.lvh.me:3000\/photos\/HXyYF_XrAuU\",\"html\":\"http:\/\/lvh.me:3000\/photos\/HXyYF_XrAuU\",\"download\":\"http:\/\/lvh.me:3000\/photos\/HXyYF_XrAuU\/download\"}},{\"id\":\"WfNOi2zxBMk\",\"user\":{\"id\":\"CH1mJBdfT94\",\"username\":\"xeromatic\",\"name\":\"Xeromatic\",\"links\":{\"self\":\"https:\/\/api.lvh.me:3000\/users\/xeromatic\",\"html\":\"http:\/\/lvh.me:3000\/xeromatic\",\"photos\":\"https:\/\/api.lvh.me:3000\/users\/xeromatic\/photos\"}},\"urls\":{\"regular\":\"https:\/\/unsplash.imgix.net\/photo-1437010302401-bffaaca5520c?q=75\\u0026fm=jpg\\u0026w=1080\\u0026fit=max\\u0026s=4ae0400baf46b221db7b4d6a874a3441\",\"small\":\"https:\/\/unsplash.imgix.net\/photo-1437010302401-bffaaca5520c?q=75\\u0026fm=jpg\\u0026w=400\\u0026fit=max\\u0026s=7b82898590a58a4c9fbf34423ab4a33a\",\"thumb\":\"https:\/\/unsplash.imgix.net\/photo-1437010302401-bffaaca5520c?q=75\\u0026fm=jpg\\u0026w=200\\u0026fit=max\\u0026s=22da536c06e8787efcf430e7b7598802\"},\"links\":{\"self\":\"https:\/\/api.lvh.me:3000\/photos\/WfNOi2zxBMk\",\"html\":\"http:\/\/lvh.me:3000\/photos\/WfNOi2zxBMk\",\"download\":\"http:\/\/lvh.me:3000\/photos\/WfNOi2zxBMk\/download\"}},{\"id\":\"teHusor7sU4\",\"user\":{\"id\":\"8xWqhQl506k\",\"username\":\"blakeverdoorn\",\"name\":\"Blake Richard Verdoorn\",\"links\":{\"self\":\"https:\/\/api.lvh.me:3000\/users\/blakeverdoorn\",\"html\":\"http:\/\/lvh.me:3000\/blakeverdoorn\",\"photos\":\"https:\/\/api.lvh.me:3000\/users\/blakeverdoorn\/photos\"}},\"urls\":{\"regular\":\"https:\/\/ununsplash.imgix.net\/photo-1436997486705-134d4c75aab4?q=75\\u0026fm=jpg\\u0026w=1080\\u0026fit=max\\u0026s=42887a751b1e388b002394cc25d133f1\",\"small\":\"https:\/\/ununsplash.imgix.net\/photo-1436997486705-134d4c75aab4?q=75\\u0026fm=jpg\\u0026w=400\\u0026fit=max\\u0026s=a6e3bf0939215dd47773d6c6eda9e0bc\",\"thumb\":\"https:\/\/ununsplash.imgix.net\/photo-1436997486705-134d4c75aab4?q=75\\u0026fm=jpg\\u0026w=200\\u0026fit=max\\u0026s=4fb46134ac0a0950a1d893148de7ccf9\"},\"links\":{\"self\":\"https:\/\/api.lvh.me:3000\/photos\/teHusor7sU4\",\"html\":\"http:\/\/lvh.me:3000\/photos\/teHusor7sU4\",\"download\":\"http:\/\/lvh.me:3000\/photos\/teHusor7sU4\/download\"}},{\"id\":\"p4LdRwehw1k\",\"user\":{\"id\":\"8xWqhQl506k\",\"username\":\"blakeverdoorn\",\"name\":\"Blake Richard Verdoorn\",\"links\":{\"self\":\"https:\/\/api.lvh.me:3000\/users\/blakeverdoorn\",\"html\":\"http:\/\/lvh.me:3000\/blakeverdoorn\",\"photos\":\"https:\/\/api.lvh.me:3000\/users\/blakeverdoorn\/photos\"}},\"urls\":{\"regular\":\"https:\/\/unsplash.imgix.net\/photo-1436990276129-47ab01d4e245?q=75\\u0026fm=jpg\\u0026w=1080\\u0026fit=max\\u0026s=7d136d059c336052def13111a0d7bb02\",\"small\":\"https:\/\/unsplash.imgix.net\/photo-1436990276129-47ab01d4e245?q=75\\u0026fm=jpg\\u0026w=400\\u0026fit=max\\u0026s=7e6198041ac81b10368d1e5325a25f4d\",\"thumb\":\"https:\/\/unsplash.imgix.net\/photo-1436990276129-47ab01d4e245?q=75\\u0026fm=jpg\\u0026w=200\\u0026fit=max\\u0026s=450d87a4323a2497e98999dc2387bd84\"},\"links\":{\"self\":\"https:\/\/api.lvh.me:3000\/photos\/p4LdRwehw1k\",\"html\":\"http:\/\/lvh.me:3000\/photos\/p4LdRwehw1k\",\"download\":\"http:\/\/lvh.me:3000\/photos\/p4LdRwehw1k\/download\"}},{\"id\":\"uh6h2pCyXig\",\"user\":{\"id\":\"8xWqhQl506k\",\"username\":\"blakeverdoorn\",\"name\":\"Blake Richard Verdoorn\",\"links\":{\"self\":\"https:\/\/api.lvh.me:3000\/users\/blakeverdoorn\",\"html\":\"http:\/\/lvh.me:3000\/blakeverdoorn\",\"photos\":\"https:\/\/api.lvh.me:3000\/users\/blakeverdoorn\/photos\"}},\"urls\":{\"regular\":\"https:\/\/ununsplash.imgix.net\/photo-1436990107126-fee768acab75?q=75\\u0026fm=jpg\\u0026w=1080\\u0026fit=max\\u0026s=f493ca37a5cdea96a2a429121e5cc960\",\"small\":\"https:\/\/ununsplash.imgix.net\/photo-1436990107126-fee768acab75?q=75\\u0026fm=jpg\\u0026w=400\\u0026fit=max\\u0026s=7a8e9121852b538bc4477d489dcf603f\",\"thumb\":\"https:\/\/ununsplash.imgix.net\/photo-1436990107126-fee768acab75?q=75\\u0026fm=jpg\\u0026w=200\\u0026fit=max\\u0026s=9a862e7f07f2301d705f391afd9a77a0\"},\"links\":{\"self\":\"https:\/\/api.lvh.me:3000\/photos\/uh6h2pCyXig\",\"html\":\"http:\/\/lvh.me:3000\/photos\/uh6h2pCyXig\",\"download\":\"http:\/\/lvh.me:3000\/photos\/uh6h2pCyXig\/download\"}},{\"id\":\"kqB7IDljjMI\",\"user\":{\"id\":\"u_dsIhbjdlA\",\"username\":\"noahbasle\",\"name\":\"Noah Basl\u00e9\",\"links\":{\"self\":\"https:\/\/api.lvh.me:3000\/users\/noahbasle\",\"html\":\"http:\/\/lvh.me:3000\/noahbasle\",\"photos\":\"https:\/\/api.lvh.me:3000\/users\/noahbasle\/photos\"}},\"urls\":{\"regular\":\"https:\/\/ununsplash.imgix.net\/photo-1436985487860-712a3b558087?q=75\\u0026fm=jpg\\u0026w=1080\\u0026fit=max\\u0026s=65d9bfbb6875a8620aa255da39aac6d4\",\"small\":\"https:\/\/ununsplash.imgix.net\/photo-1436985487860-712a3b558087?q=75\\u0026fm=jpg\\u0026w=400\\u0026fit=max\\u0026s=1b289719dc0f61cb15114e97beb66e86\",\"thumb\":\"https:\/\/ununsplash.imgix.net\/photo-1436985487860-712a3b558087?q=75\\u0026fm=jpg\\u0026w=200\\u0026fit=max\\u0026s=a4191742679378ba481c6eca00f3b2e1\"},\"links\":{\"self\":\"https:\/\/api.lvh.me:3000\/photos\/kqB7IDljjMI\",\"html\":\"http:\/\/lvh.me:3000\/photos\/kqB7IDljjMI\",\"download\":\"http:\/\/lvh.me:3000\/photos\/kqB7IDljjMI\/download\"}},{\"id\":\"KQljDf-X3SA\",\"user\":{\"id\":\"u_dsIhbjdlA\",\"username\":\"noahbasle\",\"name\":\"Noah Basl\u00e9\",\"links\":{\"self\":\"https:\/\/api.lvh.me:3000\/users\/noahbasle\",\"html\":\"http:\/\/lvh.me:3000\/noahbasle\",\"photos\":\"https:\/\/api.lvh.me:3000\/users\/noahbasle\/photos\"}},\"urls\":{\"regular\":\"https:\/\/unsplash.imgix.net\/photo-1436985382071-9da0a23a0183?q=75\\u0026fm=jpg\\u0026w=1080\\u0026fit=max\\u0026s=be1743e735470cd15a5ffbb124e06d29\",\"small\":\"https:\/\/unsplash.imgix.net\/photo-1436985382071-9da0a23a0183?q=75\\u0026fm=jpg\\u0026w=400\\u0026fit=max\\u0026s=897fdd6cfd2fffc14490b79e3517a3b1\",\"thumb\":\"https:\/\/unsplash.imgix.net\/photo-1436985382071-9da0a23a0183?q=75\\u0026fm=jpg\\u0026w=200\\u0026fit=max\\u0026s=02fff8e8e55ecafdcbae7822a7865dbe\"},\"links\":{\"self\":\"https:\/\/api.lvh.me:3000\/photos\/KQljDf-X3SA\",\"html\":\"http:\/\/lvh.me:3000\/photos\/KQljDf-X3SA\",\"download\":\"http:\/\/lvh.me:3000\/photos\/KQljDf-X3SA\/download\"}},{\"id\":\"9x-lP8dElug\",\"user\":{\"id\":\"u_dsIhbjdlA\",\"username\":\"noahbasle\",\"name\":\"Noah Basl\u00e9\",\"links\":{\"self\":\"https:\/\/api.lvh.me:3000\/users\/noahbasle\",\"html\":\"http:\/\/lvh.me:3000\/noahbasle\",\"photos\":\"https:\/\/api.lvh.me:3000\/users\/noahbasle\/photos\"}},\"urls\":{\"regular\":\"https:\/\/unsplash.imgix.net\/photo-1436985226304-226aab488ab3?q=75\\u0026fm=jpg\\u0026w=1080\\u0026fit=max\\u0026s=7281080939be752385e039323bf5bd26\",\"small\":\"https:\/\/unsplash.imgix.net\/photo-1436985226304-226aab488ab3?q=75\\u0026fm=jpg\\u0026w=400\\u0026fit=max\\u0026s=6204a785bc1ed3e4cf50e8e216cbb6e6\",\"thumb\":\"https:\/\/unsplash.imgix.net\/photo-1436985226304-226aab488ab3?q=75\\u0026fm=jpg\\u0026w=200\\u0026fit=max\\u0026s=c73e7d51a94e7f1eaa430d4988770937\"},\"links\":{\"self\":\"https:\/\/api.lvh.me:3000\/photos\/9x-lP8dElug\",\"html\":\"http:\/\/lvh.me:3000\/photos\/9x-lP8dElug\",\"download\":\"http:\/\/lvh.me:3000\/photos\/9x-lP8dElug\/download\"}}]"
+    }
+},{
+    "request": {
+        "method": "GET",
         "url": "https:\/\/api.unsplash.com\/photos\/search?query=coffee&page=1&per_page=10",
         "headers": {
             "Host": "api.unsplash.com",
@@ -434,5 +471,47 @@
             "Content-Length": "2073"
         },
         "body": "{\"id\":\"v4-S_O-JBQs\",\"width\":null,\"height\":null,\"color\":null,\"downloads\":0,\"likes\":0,\"liked_by_user\":false,\"exif\":{\"make\":null,\"model\":null,\"exposure_time\":null,\"aperture\":null,\"focal_length\":null,\"iso\":null},\"current_user_collections\":[],\"urls\":{\"raw\":\"https:\/\/images.unsplash.com\/development\/test.jpg\",\"full\":\"https:\/\/images.unsplash.com\/development\/test.jpg?ixlib=rb-0.3.5\\u0026q=80\\u0026fm=jpg\\u0026crop=entropy\\u0026s=3dc9e043e7d1be1bca1eb99d60ed410b\",\"regular\":\"https:\/\/images.unsplash.com\/development\/test.jpg?ixlib=rb-0.3.5\\u0026q=80\\u0026fm=jpg\\u0026crop=entropy\\u0026w=1080\\u0026fit=max\\u0026s=2e1b18e4d46c206a959d57258bc83897\",\"small\":\"https:\/\/images.unsplash.com\/development\/test.jpg?ixlib=rb-0.3.5\\u0026q=80\\u0026fm=jpg\\u0026crop=entropy\\u0026w=400\\u0026fit=max\\u0026s=92a311b148de22b8110b098eda46337e\",\"thumb\":\"https:\/\/images.unsplash.com\/development\/test.jpg?ixlib=rb-0.3.5\\u0026q=80\\u0026fm=jpg\\u0026crop=entropy\\u0026w=200\\u0026fit=max\\u0026s=7398a352768884d3c22a0605e43db892\"},\"categories\":[],\"links\":{\"self\":\"http:\/\/api.lvh.me:3000\/photos\/v4-S_O-JBQs\",\"html\":\"http:\/\/lvh.me:3000\/photos\/v4-S_O-JBQs\",\"download\":\"http:\/\/lvh.me:3000\/photos\/v4-S_O-JBQs\/download\"},\"user\":{\"id\":\"8VpB0GYJMZQ\",\"username\":\"dechuck\",\"name\":\"Charles Lalonde\",\"profile_image\":{\"small\":\"https:\/\/images.unsplash.com\/profile-1452969963718-2d46cdffd366?ixlib=rb-0.3.5\\u0026q=80\\u0026fm=jpg\\u0026crop=faces\\u0026fit=crop\\u0026h=32\\u0026w=32\\u0026s=17967811237a4d1f123ce4bef1dc0ff5\",\"medium\":\"https:\/\/images.unsplash.com\/profile-1452969963718-2d46cdffd366?ixlib=rb-0.3.5\\u0026q=80\\u0026fm=jpg\\u0026crop=faces\\u0026fit=crop\\u0026h=64\\u0026w=64\\u0026s=1865f4d6a3ab5da961fe8f49a9d9c566\",\"large\":\"https:\/\/images.unsplash.com\/profile-1452969963718-2d46cdffd366?ixlib=rb-0.3.5\\u0026q=80\\u0026fm=jpg\\u0026crop=faces\\u0026fit=crop\\u0026h=128\\u0026w=128\\u0026s=35d0f86d845ad86e192ad6ed18f88b6d\"},\"links\":{\"self\":\"http:\/\/api.lvh.me:3000\/users\/dechuck\",\"html\":\"http:\/\/lvh.me:3000\/dechuck\",\"photos\":\"http:\/\/api.lvh.me:3000\/users\/dechuck\/photos\",\"likes\":\"http:\/\/api.lvh.me:3000\/users\/dechuck\/likes\"}}}"
+    }
+},{
+    "request": {
+        "method": "GET",
+        "url": "https:\/\/api.unsplash.com\/photos\/curated?page=1&per_page=10",
+        "headers": {
+            "Host": "api.unsplash.com",
+            "Accept-Encoding": null,
+            "User-Agent": "GuzzleHttp\/6.2.1 curl\/7.35.0 PHP\/5.6.23-2+deb.sury.org~trusty+1",
+            "Authorization": "Bearer 582c5d7ebe28bd707751a43c8e22dc5c0a4ba0a60dbe69d520677f47b7cfcc1b",
+            "Accept": null
+        }
+    },
+    "response": {
+        "status": {
+            "http_version": "1.1",
+            "code": "401",
+            "message": "Unauthorized"
+        },
+        "headers": {
+            "Server": "Cowboy",
+            "Content-Type": "application\/json",
+            "Access-Control-Allow-Origin": "*",
+            "Access-Control-Request-Method": "*",
+            "Access-Control-Allow-Headers": "*",
+            "Access-Control-Expose-Headers": "Link,X-Total,X-Per-Page,X-RateLimit-Limit,X-RateLimit-Remaining",
+            "Cache-Control": "no-cache",
+            "X-Request-Id": "ba2acd1c-d5d5-4dda-b901-03cf3f3e08e0",
+            "X-Ratelimit-Limit": "5000",
+            "X-Ratelimit-Remaining": "4994",
+            "X-Runtime": "0.020925",
+            "Strict-Transport-Security": "max-age=31536000",
+            "Via": "1.1 vegur, 1.1 varnish",
+            "Content-Length": "55",
+            "Accept-Ranges": "bytes",
+            "Date": "Sun, 21 Aug 2016 17:25:22 GMT",
+            "Connection": "keep-alive",
+            "X-Served-By": "cache-ams4145-AMS",
+            "X-Cache": "MISS",
+            "X-Cache-Hits": "0"
+        },
+        "body": "{\"errors\":[\"OAuth error: The access token is invalid\"]}"
     }
 }]


### PR DESCRIPTION
Hey team!

This patch adds support for the /photos/curated endpoint.
The test is using the same return data as the /photos endpoint, hope that's ok.

Cheers
Jan