### PR TITLE
Detect and report rate limit errors.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,5 @@ before_script:
   - composer install --prefer-source --no-interaction
   - mkdir -p build/logs
 script:
-  - phpunit
+  - vendor/bin/phpunit
   - vendor/bin/coveralls

--- a/src/Endpoint.php
+++ b/src/Endpoint.php
@@ -13,6 +13,8 @@ namespace Crew\Unsplash;
  */
 class Endpoint
 {
+    const RATE_LIMIT_ERROR_MESSAGE = "Rate Limit Exceeded";
+
     /** @var array All parameters that an endpoint can have */
     private $parameters;
 
@@ -21,7 +23,7 @@ class Endpoint
 
     /**
      * Construct a new endpoint object and set the parameters from an array
-     * 
+     *
      * @param array $parameters
      */
     public function __construct($parameters = [])
@@ -32,7 +34,7 @@ class Endpoint
 
     /**
      * Merge old parameters with the new one
-     * 
+     *
      * @param  array $parameters The parameters to update on the object
      * @return void
      */
@@ -43,7 +45,7 @@ class Endpoint
 
     /**
      * Magic method to retrieve a specific parameter in the parameters array
-     * 
+     *
      * @param  string $key
      * @return mixed
      */
@@ -55,14 +57,14 @@ class Endpoint
     /**
      * Check if the HTTP method is accepted and send a HTTP request to it.
      * Retrieve error from the request and throw a new error
-     * 
+     *
      * @param  string $method HTTP action to trigger
      * @param  array $arguments Array containing all the parameters pass to the magic method
-     * 
+     *
      * @throws \Crew\Unsplash\Exception if the HTTP request failed
      *
      * @see Crew\Unsplash\HttpClient::send()
-     * 
+     *
      * @return \GuzzleHttp\Psr7\Response
      */
     public static function __callStatic($method, $arguments)
@@ -111,7 +113,7 @@ class Endpoint
 
     /**
      * Retrieve the response status code and determine if the request was successful.
-     * 
+     *
      * @param  \GuzzleHttp\Psr7\Response $response of the HTTP request
      * @return boolean
      */
@@ -122,18 +124,23 @@ class Endpoint
 
     /**
      * Retrieve the error messages in the body
-     * 
+     *
      * @param  \GuzzleHttp\Psr7\Response $response of the HTTP request
      * @return array Array of error messages
      */
     private static function getErrorMessage($response)
     {
-        $message = json_decode($response->getBody(), true);
+        $body = $response->getBody();
+
+        $message = json_decode($body, true);
         $errors = [];
 
         if (is_array($message) && isset($message['errors'])) {
             $errors = $message['errors'];
         }
+
+        if ($body == self::RATE_LIMIT_ERROR_MESSAGE)
+            $errors = [self::RATE_LIMIT_ERROR_MESSAGE];
 
         return $errors;
     }

--- a/tests/EndpointTest.php
+++ b/tests/EndpointTest.php
@@ -58,4 +58,17 @@ class EndpointTest extends BaseTest
         $this->assertEquals('mock_test', $endpoint->test);
         $this->assertEquals('mock_1', $endpoint->test_1);
     }
+
+    /**
+     * @expectedException Crew\Unsplash\Exception
+     * @expectedExceptionCode 403
+     */
+    public function testRateLimitError()
+    {
+        VCR::insertCassette('endpoint.yml');
+
+        $res = Unsplash\Endpoint::__callStatic('get', ['categories/3', []]);
+
+        VCR::eject();
+    }
 }

--- a/tests/fixtures/endpoint.yml
+++ b/tests/fixtures/endpoint.yml
@@ -32,4 +32,43 @@
         },
         "body": "{\"id\":2,\"title\":\"Buildings\",\"photo_count\":4738,\"links\":{\"self\":\"https:\/\/api.unsplash.com:80\/categories\/2\",\"photos\":\"https:\/\/api.unsplash.com:80\/categories\/2\/photos\"}}"
     }
+},{
+    "request": {
+        "method": "GET",
+        "url": "https:\/\/api.unsplash.com\/categories\/3",
+        "headers": {
+            "Host": "api.unsplash.com",
+            "Accept-Encoding": null,
+            "User-Agent": "GuzzleHttp\/6.2.1 curl\/7.50.3 PHP\/5.6.27",
+            "Authorization": "Bearer 582c5d7ebe28bd707751a43c8e22dc5c0a4ba0a60dbe69d520677f47b7cfcc1b",
+            "Accept": null
+        }
+    },
+    "response": {
+        "status": {
+            "http_version": "1.1",
+            "code": "403",
+            "message": "Forbidden"
+        },
+        "headers": {
+            "Server": "Cowboy",
+            "X-Ratelimit-Limit": "100",
+            "X-Ratelimit-Remaining": "0",
+            "X-Request-Id": "0bb91f82-2683-4f8a-ad26-62db754569f2",
+            "X-Runtime": "0.191253",
+            "Strict-Transport-Security": "max-age=31536000",
+            "Via": "1.1 vegur, 1.1 varnish, 1.1 varnish",
+            "Fastly-Debug-Digest": "118a44c8f4313da7b96315796fd94e0a0bb44ff893010105fae9bb2eb6275dd3",
+            "Content-Length": "19",
+            "Accept-Ranges": "bytes",
+            "Date": "Mon, 20 Mar 2017 20:56:24 GMT",
+            "Connection": "keep-alive",
+            "X-Served-By": "cache-iad2139-IAD, cache-ord1732-ORD",
+            "X-Cache": "MISS, MISS",
+            "X-Cache-Hits": "0, 0",
+            "X-Timer": "S1490043384.493334,VS0,VE224",
+            "Vary": "Origin"
+        },
+        "body": "Rate Limit Exceeded"
+    }
 }]


### PR DESCRIPTION
Closes #48.

The rate limit exceeded message isn't in an `errors` array like other API error messages (which is a separate issue...), and so wouldn't be output properly in the exception message.