### PR TITLE
Append UTM values to links pointing to unsplash.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,14 @@ Before using, configure the client with your application ID and secret. If you d
 
 Note that if you're just using actions that require the [public permission scope](#permission-scopes), only the `applicationId` is required.
 
+Note that if utmSource is omitted from $credentials a notice will be raised 
+
 ```php
 Crew\Unsplash\HttpClient::init([
 	'applicationId'	=> 'YOUR APPLICATION ID',
 	'secret'		=> 'YOUR APPLICATION SECRET',
-	'callbackUrl'	=> 'https://your-application.com/oauth/callback'
+	'callbackUrl'	=> 'https://your-application.com/oauth/callback',
+	'utmSource' => 'NAME OF YOUR APPLICATION'
 ]);
 ```
 ### Authorization workflow

--- a/src/HttpClient.php
+++ b/src/HttpClient.php
@@ -17,7 +17,7 @@ class HttpClient
     private $host = 'api.unsplash.com';
     private $scheme = 'https';
 
-    public static $utmSource = '';
+    public static $utmSource = 'api_app';
 
     /**
      * Crew\Unsplash\Connection object link to the HttpClient
@@ -64,9 +64,10 @@ class HttpClient
         if (!isset($credentials['utmSource']) || empty($credentials['utmSource'])) {
             $terms = "https://community.unsplash.com/developersblog/unsplash-api-terms-explained#block-yui_3_17_2_1_1490972762425_202608";
             trigger_error("utmSource is required as part of API Terms: {$terms}");
-            $credentials['utmSource'] = '';
+        } else {
+            self::$utmSource = $credentials['utmSource'];
         }
-        self::$utmSource = $credentials['utmSource'];
+
         self::$connection = new Connection(self::initProvider($credentials), $token);
     }
 

--- a/src/HttpClient.php
+++ b/src/HttpClient.php
@@ -43,6 +43,7 @@ class HttpClient
      *         ['applicationId']     string     Application id. This value is needed accross all requests
      *         ['secret']            string    Application secret. Application secret is needed for OAuth authentification
      *         ['callbackUrl']     string    Callback url. After OAuth authentification, the user will be redirected to this url.
+     *         ['utmSource'] string Name of your application. This is required, a notice will be raised if missing
      *
      * $accessToken             array     Access Token information
      *         ['access_token']    string     Access Token identifier

--- a/src/HttpClient.php
+++ b/src/HttpClient.php
@@ -17,6 +17,8 @@ class HttpClient
     private $host = 'api.unsplash.com';
     private $scheme = 'https';
 
+    public static $utmSource = '';
+
     /**
      * Crew\Unsplash\Connection object link to the HttpClient
      * Need to be set on the class before running anything else
@@ -58,6 +60,12 @@ class HttpClient
             $token = self::initAccessToken($accessToken);
         }
 
+        if (!isset($credentials['utmSource']) || empty($credentials['utmSource'])) {
+            $terms = "https://community.unsplash.com/developersblog/unsplash-api-terms-explained#block-yui_3_17_2_1_1490972762425_202608";
+            trigger_error("utmSource is required as part of API Terms: {$terms}");
+            $credentials['utmSource'] = '';
+        }
+        self::$utmSource = $credentials['utmSource'];
         self::$connection = new Connection(self::initProvider($credentials), $token);
     }
 

--- a/tests/CategoryTest.php
+++ b/tests/CategoryTest.php
@@ -12,6 +12,14 @@ class CategoryTest extends BaseTest
         parent::setUp();
 
         $connection = new Unsplash\Connection($this->provider, $this->accessToken);
+        Unsplash\HttpClient::init([
+            'applicationId' => 'mock_application_id',
+            'utmSource' => 'test'
+        ], [
+            'access_token'    => 'mock_access_token',
+            'refresh_token' => 'mock_refresh_token_1',
+            'expires_in' => time() + 3600
+        ]);
         Unsplash\HttpClient::$connection = $connection;
     }
 

--- a/tests/EndpointTest.php
+++ b/tests/EndpointTest.php
@@ -20,7 +20,8 @@ class EndpointTest extends BaseTest
             [
                 'clientId' => 'mock_client_id',
                 'clientSecret' => 'mock_secret',
-                'redirectUri' => 'none'
+                'redirectUri' => 'none',
+                'utmSource' => 'test'
             ],
             [
                 'access_token' => getenv('ACCESS_TOKEN'),

--- a/tests/HttpClientTest.php
+++ b/tests/HttpClientTest.php
@@ -40,6 +40,7 @@ class HttpClientTest extends BaseTest
     {
         Unsplash\HttpClient::init([
             'applicationId' => 'mock_application_id',
+            'utmSource' => 'test'
         ]);
 
         $this->assertInstanceOf('Crew\Unsplash\Connection', Unsplash\HttpClient::$connection);
@@ -50,6 +51,7 @@ class HttpClientTest extends BaseTest
     {
         Unsplash\HttpClient::init([
             'applicationId' => 'mock_application_id',
+            'utmSource' => 'test'
         ], [
             'access_token'    => 'mock_access_token',
             'refresh_token' => 'mock_refresh_token_1',
@@ -59,10 +61,26 @@ class HttpClientTest extends BaseTest
         $this->assertEquals('Bearer mock_access_token', Unsplash\HttpClient::$connection->getAuthorizationToken());
     }
 
+    /**
+     * @expectedException \PHPUnit_Framework_Error_Notice
+     */
+    public function testInitWithoutUtmSourceRaisesNotice()
+    {
+        $this->setExpectedExceptionFromAnnotation();
+        Unsplash\HttpClient::init([
+            'applicationId' => 'mock_application_id',
+        ], [
+            'access_token'    => 'mock_access_token',
+            'refresh_token' => 'mock_refresh_token_1',
+            'expires_in' => time() + 3600
+        ]);
+    }
+
     public function testInitConnectionWithAccessTokenObject()
     {
         Unsplash\HttpClient::init([
             'applicationId' => 'mock_application_id',
+            'utmSource' => 'test'
         ], $this->accessToken);
 
         $this->assertEquals('Bearer ' . getenv('ACCESS_TOKEN'), Unsplash\HttpClient::$connection->getAuthorizationToken());
@@ -72,6 +90,7 @@ class HttpClientTest extends BaseTest
     {
         Unsplash\HttpClient::init([
             'applicationId' => 'mock_application_id',
+            'utmSource' => 'test'
         ], 'access_token');
 
         $this->assertEquals('Client-ID mock_application_id', Unsplash\HttpClient::$connection->getAuthorizationToken());

--- a/tests/PhotoTest.php
+++ b/tests/PhotoTest.php
@@ -15,6 +15,7 @@ class PhotoTest extends BaseTest
 
         $connection = new Unsplash\Connection($this->provider, $this->accessToken);
         Unsplash\HttpClient::$connection = $connection;
+        Unsplash\HttpClient::$utmSource = 'test';
     }
 
     public function testFindPhoto()
@@ -37,12 +38,13 @@ class PhotoTest extends BaseTest
         VCR::eject();
 
         $this->assertEquals(10, $photos->count());
+        $expectedQueryString = 'utm_source=test&utm_medium=referral&utm_campaign=api-credit';
+        $this->assertContains($expectedQueryString, $photos[0]->links['html']);
+        $this->assertContains($expectedQueryString, $photos[0]->links['download']);
+        $this->assertNotContains($expectedQueryString, $photos[0]->links['self']);
+        $this->assertContains($expectedQueryString, $photos[0]->user['links']['html']);
     }
 
-
-    /**
-     * @group hugh
-     */
     public function testFindCuratedPhotos()
     {
         VCR::insertCassette('photos.yml');


### PR DESCRIPTION
### Closes #58

Notice is raised if utmSource is missing from `$credentials` passed to `HttpClient::init`

Example link with UTM values:
`http://unsplash.com/photos/JC9i2Jy05uQ/download?utm_source=my_application&utm_medium=referral&utm_campaign=api-credit`

Defaults to `api_app` otherwise
