### PR TITLE
'orientation' and 'collections' parameters on photo search

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,8 +109,8 @@ Retrieve a single page of photo results depending on search results.
 `$search`      | string | Required
 `$page`        | int    | Opt *(Default: 1)*
 `$per_page`    | int    | Opt *(Default: 10 / Maximum: 30)*
-`$orientation` | string | Opt *(Default: null)*
-`$collections` | string | Opt *(Default: null)*
+`$orientation` | string | Opt *(Default: null / Available: "landscape", "portrait", "squarish")*
+`$collections` | string | Opt *(Default: null / If multiple, comma-separated)*
 
 **Example**
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Some parameters are identical across all methods:
 
 <div id="search-photos" />
 
-#### Crew\Unsplash\Search::photos($search, $page, $per_page)
+#### Crew\Unsplash\Search::photos($search, $page, $per_page, $orientation, $collections)
 
 Retrieve a single page of photo results depending on search results.
 
@@ -107,14 +107,21 @@ Retrieve a single page of photo results depending on search results.
   Argument     | Type   | Opt/Required
 ---------------|--------|--------------
 `$search`      | string | Required
-`$per_page`    | int    | Opt *(Default: 10 / Maximum: 30)*
 `$page`        | int    | Opt *(Default: 1)*
+`$per_page`    | int    | Opt *(Default: 10 / Maximum: 30)*
+`$orientation` | string | Opt *(Default: null)*
+`$collections` | string | Opt *(Default: null)*
 
 **Example**
 
 
 ```php
-Crew\Unsplash\Search::photos($search, $page, $per_page);
+$search = 'forest';
+$page = 3;
+$per_page = 15;
+$orientation = 'landscape';
+
+Crew\Unsplash\Search::photos($search, $page, $per_page, $orientation);
 ```
 
 ----

--- a/src/Search.php
+++ b/src/Search.php
@@ -12,21 +12,33 @@ class Search extends Endpoint
      * Retrieve a single page of photo results depending on search results
      * Returns ArrayObject that contain PageResult object.
      *
-     * @param  string  $search   Search terms.
-     * @param  integer $page     Page from which the photos need to be retrieve
-     * @param  integer $per_page Number of element in a page
+     * @param  string  $search       Search terms.
+     * @param  integer $page         Page number to retrieve. (Optional; default: 1)
+     * @param  integer $per_page     Number of items per page. (Optional; default: 10)
+     * @param  string  $orientation  Filter search results by photo orientation. Valid values are landscape,
+     *                               portrait, and squarish. (Optional)
+     * @param  string  $collections  Collection ID(‘s) to narrow search. If multiple, comma-separated. (Optional)
      * @return PageResult
      */
-    public static function photos($search, $page = 1, $per_page = 10)
+    public static function photos($search, $page = 1, $per_page = 10, $orientation = null, $collections = null)
     {
+        $query = [
+            'query' => $search,
+            'page' => $page,
+            'per_page' => $per_page
+        ];
+
+        if ( ! empty($orientation)) {
+            $query['orientation'] = $orientation;
+        }
+
+        if ( ! empty($collections)) {
+            $query['collections'] = $collections;
+        }
+
         $photos = self::get(
             "/search/photos",
-            [ 'query' => [
-                    'query' => $search,
-                    'page' => $page,
-                    'per_page' => $per_page
-                ]
-            ]
+            [ 'query' => $query ]
         );
 
         return self::getPageResult($photos->getBody(), $photos->getHeaders(), Photo::class);


### PR DESCRIPTION
Add 'orientation' and 'collections' parameters to photo search. 

They are optional and default to null.

They are only included in the API call as parameters if they're not empty.

The readme file is updated to show these two new parameters.