### PR TITLE
Update composer.json with current teammates

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,17 @@
 {
-  "name": "crewlabs/unsplash",
-  "description": "Wrapper to access information from Unsplash API more easily",
+  "name": "unsplash/unsplash",
+  "description": "Wrapper to access the Unsplash API and photo library",
   "minimum-stability": "stable",
-  "license": "CC0",
+  "license": "MIT",
   "authors": [
+    {
+      "name": "Aaron Klaassen",
+      "email": "aaron@unsplash.com"
+    },
+    {
+      "name": "Luke Chesser",
+      "email": "luke@unsplash.com"
+    },
     {
       "name": "Charles Lalonde",
       "email": "charles@pickcrew.com"


### PR DESCRIPTION
### Overview

- composer file is out of date and doesn't list any current Unsplash teammates