### PR TITLE
Require guzzlehttp/guzzle 6.3.0 or higher

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
   ],
   "require": {
     "php": ">=5.6.0",
-    "guzzlehttp/guzzle": "6.3.0",
+    "guzzlehttp/guzzle": "^6.3.0",
     "league/oauth2-client": ">=1.4.2",
     "hughbertd/oauth2-unsplash": ">=1.0.3"
 


### PR DESCRIPTION
The package is now uses a version of guzzlehttp/guzzle that is locked at 6.3.0, which is causing some issues when the main application requires a higher version.

This PR changes that so that the packages works with 6.3.*.