### PR TITLE
Photos and collections returning PageResult

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,12 +83,17 @@ For more information about the the responses for each call, refer to the [offici
 
 Some parameters are identical across all methods:
 
-  param     | Description
-------------|-----------------------------------------------------
-`$per_page` | Defines the number of objects per page. *Default 10*
-`$page`     | Defines the offset page. *Default 1*
+  param              | Description
+---------------------|-----------------------------------------------------
+`$per_page`          | Defines the number of objects per page. *Default 10*
+`$page`              | Defines the offset page. *Default 1*
+`$returnArrayObject` | Defines if method should return ArrayObject. *Default true*
 
 *Note: The methods that return multiple objects return an `ArrayObject`, which acts like a normal stdClass.*
+
+*If `$returnArrayObject` is set to `false` they return `PageResult` which contains array of results, total number of elements, page and total number of pages.*
+ 
+*There are three exceptions: `Search::collections`, `Search::photos` and `Search::users` always returns `PageResult`.*
 
 ----
 
@@ -173,16 +178,23 @@ Retrieve the list of curated collections.
 
 **Arguments**
 
-  Argument     | Type | Opt/Required
----------------|------|--------------
-`$per_page`    | int  | Opt *(Default: 10 / Maximum: 30)*
-`$page`        | int  | Opt *(Default: 1)*
+  Argument           | Type | Opt/Required
+---------------------|------|--------------
+`$per_page`          | int  | Opt *(Default: 10 / Maximum: 30)*
+`$page`              | int  | Opt *(Default: 1)*
+`$returnArrayObject` | bool | Opt *(Default: true)*
 
 **Example**
 
 
 ```php
 Crew\Unsplash\CuratedCollection::all($page, $per_page);
+```
+
+**Example for returning PageResult instead of ArrayObject**
+
+```php
+Crew\Unsplash\CuratedCollection::all($page, $per_page, false);
 ```
 
 ----
@@ -211,16 +223,24 @@ Retrieve photos from a curated collection.
 
 **Arguments**
 
-  Argument     | Type | Opt/Required
----------------|------|--------------
-`$per_page`    | int  | Opt *(Default: 10 / Maximum: 30)*
-`$page`        | int  | Opt *(Default: 1)*
+  Argument           | Type | Opt/Required
+---------------------|------|--------------
+`$per_page`          | int  | Opt *(Default: 10 / Maximum: 30)*
+`$page`              | int  | Opt *(Default: 1)*
+`$returnArrayObject` | bool | Opt *(Default: true)*
 
 **Example**
 
 ```php
 $collection = Crew\Unsplash\CuratedCollection::find(integer $id);
 $photos = $collection->photos($page, $per_page);
+```
+
+**Example for returning PageResult instead of ArrayObject**
+
+```php
+$collection = Crew\Unsplash\CuratedCollection::find(integer $id);
+$photos = $collection->photos($page, $per_page, false);
 ```
 
 ----
@@ -232,16 +252,23 @@ Retrieve the list of collections.
 
 **Arguments**
 
-  Argument     | Type | Opt/Required
----------------|------|--------------
-`$per_page`    | int  | Opt *(Default: 10 / Maximum: 30)*
-`$page`        | int  | Opt *(Default: 1)*
+  Argument           | Type | Opt/Required
+---------------------|------|--------------
+`$per_page`          | int  | Opt *(Default: 10 / Maximum: 30)*
+`$page`              | int  | Opt *(Default: 1)*
+`$returnArrayObject` | bool | Opt *(Default: true)*
 
 **Example**
 
 
 ```php
 Crew\Unsplash\Collection::all($page, $per_page);
+```
+
+**Example for returning PageResult instead of ArrayObject**
+
+```php
+Crew\Unsplash\Collection::all($page, $per_page, false);
 ```
 
 ----
@@ -251,16 +278,23 @@ Retrieve list of featured collections.
 
 **Arguments**
 
-  Argument     | Type | Opt/Required
----------------|------|--------------
-`$per_page`    | int  | Opt *(Default: 10 / Maximum: 30)*
-`$page`        | int  | Opt *(Default: 1)*
+  Argument           | Type | Opt/Required
+---------------------|------|--------------
+`$per_page`          | int  | Opt *(Default: 10 / Maximum: 30)*
+`$page`              | int  | Opt *(Default: 1)*
+`$returnArrayObject` | bool | Opt *(Default: true)*
 
 **Example**
 
 
 ```php
 Crew\Unsplash\Collection::featured($page, $per_page);
+```
+
+**Example for returning PageResult instead of ArrayObject**
+
+```php
+Crew\Unsplash\Collection::featured($page, $per_page, false);
 ```
 
 ----
@@ -272,9 +306,9 @@ Retrieve list of featured collections.
 
 **Arguments**
 
-  Argument     | Type | Opt/Required
----------------|------|--------------
-
+  Argument           | Type | Opt/Required
+---------------------|------|--------------
+`$returnArrayObject` | bool | Opt *(Default: true)*
 
 **Example**
 
@@ -282,6 +316,13 @@ Retrieve list of featured collections.
 ```php
 $collection = Crew\Unsplash\Collection::find($id);
 $collection->related();
+```
+
+**Example for returning PageResult instead of ArrayObject**
+
+```php
+$collection = Crew\Unsplash\Collection::find($id);
+$collection->related(false);
 ```
 
 ----
@@ -310,16 +351,24 @@ Retrieve photos from a collection.
 
 **Arguments**
 
-  Argument     | Type | Opt/Required
----------------|------|--------------
-`$per_page`    | int  | Opt *(Default: 10 / Maximum: 30)*
-`$page`        | int  | Opt *(Default: 1)*
+  Argument           | Type | Opt/Required
+---------------------|------|--------------
+`$per_page`          | int  | Opt *(Default: 10 / Maximum: 30)*
+`$page`              | int  | Opt *(Default: 1)*
+`$returnArrayObject` | bool | Opt *(Default: true)*
 
 **Example**
 
 ```php
 $collection = Crew\Unsplash\Collection::find(integer $id);
 $photos = $collection->photos($page, $per_page);
+```
+
+**Example for returning PageResult instead of ArrayObject**
+
+```php
+$collection = Crew\Unsplash\Collection::find(integer $id);
+$photos = $collection->photos($page, $per_page, false);
 ```
 
 ----
@@ -437,16 +486,23 @@ Retrieve a list of photos.
 
 **Arguments**
 
-  Argument     | Type | Opt/Required
----------------|------|--------------
-`$per_page`    | int  | Opt *(Default: 10 / Maximum: 30)*
-`$page`        | int  | Opt *(Default: 1)*
-`$order_by` | string | Opt *(Default: latest / Available: oldest, popular)*
+  Argument           | Type   | Opt/Required
+---------------------|--------|--------------
+`$per_page`          | int    | Opt *(Default: 10 / Maximum: 30)*
+`$page`              | int    | Opt *(Default: 1)*
+`$order_by`          | string | Opt *(Default: latest / Available: oldest, popular)*
+`$returnArrayObject` | bool   | Opt *(Default: true)*
 
 **Example**
 
 ```php
 Crew\Unsplash\Photo::all($page, $per_page, $order_by);
+```
+
+**Example for returning PageResult instead of ArrayObject**
+
+```php
+Crew\Unsplash\Photo::all($page, $per_page, $order_by, false);
 ```
 
 
@@ -457,16 +513,23 @@ Retrieve a list of curated photos.
 
 **Arguments**
 
-  Argument     | Type | Opt/Required
----------------|------|--------------
-`$per_page`    | int  | Opt *(Default: 10 / Maximum: 30)*
-`$page`        | int  | Opt *(Default: 1)*
-`$order_by` | string | Opt *(Default: latest / Available: oldest, popular)*
+  Argument           | Type   | Opt/Required
+---------------------|--------|--------------
+`$per_page`          | int    | Opt *(Default: 10 / Maximum: 30)*
+`$page`              | int    | Opt *(Default: 1)*
+`$order_by`          | string | Opt *(Default: latest / Available: oldest, popular)*
+`$returnArrayObject` | bool   | Opt *(Default: true)*
 
 **Example**
 
 ```php
 Crew\Unsplash\Photo::curated($page, $per_page, $order_by);
+```
+
+**Example for returning PageResult instead of ArrayObject**
+
+```php
+Crew\Unsplash\Photo::curated($page, $per_page, $order_by, false);
 ```
 
 ----

--- a/src/Photo.php
+++ b/src/Photo.php
@@ -11,6 +11,17 @@ namespace Crew\Unsplash;
 class Photo extends Endpoint
 {
     private $photographer;
+    private $parameters;
+
+    public function __construct(array $parameters = [])
+    {
+        parent::__construct($parameters);
+        $this->parameters = $parameters;
+    }
+
+    public function getParameters() {
+        return $this->parameters;
+    }
 
     /**
      * Retrieve the a photo object from the ID specified
@@ -32,17 +43,28 @@ class Photo extends Endpoint
      * @param  integer $page Page from which the photos need to be retrieve
      * @param  integer $per_page Number of element in a page
      * @param string $order_by Order in which to retrieve photos
-     * @return ArrayObject of Photos
+     * @param bool $returnArrayObject Does function should return photos as ArrayObject (backward compatibility)
+     * @return ArrayObject|PageResult of Photos
      */
-    public static function all($page = 1, $per_page = 10, $order_by = 'latest')
+    public static function all($page = 1, $per_page = 10, $order_by = 'latest', $returnArrayObject = true)
     {
         $photos = self::get("/photos", [
             'query' => ['page' => $page, 'per_page' => $per_page, 'order_by' => $order_by]
         ]);
 
-        $photosArray = self::getArray($photos->getBody(), get_called_class());
+        $photosArray = self::getArray($photos->getBody(), Photo::class);
+        $arrayObjects = new ArrayObject($photosArray, $photos->getHeaders());
+        if($returnArrayObject) {
+            return $arrayObjects;
+        }
+        $pageResults['results'] = [];
+        foreach($photosArray as $photo){
+            $pageResults['results'][] = $photo->getParameters();
+        }
+        $pageResults['total_pages'] = $arrayObjects->totalPages();
+        $pageResults['total'] = $arrayObjects->count();
 
-        return new ArrayObject($photosArray, $photos->getHeaders());
+        return self::getPageResult(json_encode($pageResults), $photos->getHeaders(), Photo::class);
     }
 
 
@@ -53,17 +75,28 @@ class Photo extends Endpoint
      * @param  integer $page Page from which the photos need to be retrieve
      * @param  integer $per_page Number of element in a page
      * @param string $order_by Order in which to retrieve photos
-     * @return ArrayObject of Photos
+     * @param bool $returnArrayObject Does function should return photos as ArrayObject (backward compatibility)
+     * @return ArrayObject|PageResult of Photos
      */
-    public static function curated($page = 1, $per_page = 10, $order_by = 'latest')
+    public static function curated($page = 1, $per_page = 10, $order_by = 'latest', $returnArrayObject = true)
     {
         $photos = self::get("/photos/curated", [
             'query' => ['page' => $page, 'per_page' => $per_page, 'order_by' => $order_by]
         ]);
 
         $photosArray = self::getArray($photos->getBody(), get_called_class());
+        $arrayObjects = new ArrayObject($photosArray, $photos->getHeaders());
+        if($returnArrayObject) {
+            return $arrayObjects;
+        }
+        $pageResults['results'] = [];
+        foreach($photosArray as $photo){
+            $pageResults['results'][] = $photo->getParameters();
+        }
+        $pageResults['total_pages'] = $arrayObjects->totalPages();
+        $pageResults['total'] = $arrayObjects->count();
 
-        return new ArrayObject($photosArray, $photos->getHeaders());
+        return self::getPageResult(json_encode($pageResults), $photos->getHeaders(), Photo::class);
     }
 
     /**
@@ -89,7 +122,7 @@ class Photo extends Endpoint
                 'orientation' => $orientation,
                 'page' => $page,
                 'per_page' => $per_page
-                ]
+            ]
             ]
         );
 


### PR DESCRIPTION
I've added the possibility for returning PageResult for photos and collections because for me it is much easier to maintain only one return type across searching and listing photos and collections. I hope it also resolves the apapazisis's issue #72  .