### PR TITLE
Add method to view remaining rate limit

### DIFF
--- a/src/ArrayObject.php
+++ b/src/ArrayObject.php
@@ -38,6 +38,8 @@ class ArrayObject extends \ArrayObject
     const TOTAL = 'X-Total';
 
     const PER_PAGE = 'X-Per-Page';
+    
+    const RATE_LIMIT_REMAINING = 'X-Ratelimit-Remaining';
 
     /**
      * @param array|object $input
@@ -145,5 +147,14 @@ class ArrayObject extends \ArrayObject
         $this->pagesProcessed = true;
 
         return $this->pages;
+    }
+
+    /**
+     * Return the rate limit remaining
+     * @return int
+     */
+    public function rateLimitRemaining()
+    {
+        return intval($this->headers[self::RATE_LIMIT_REMAINING][0]);
     }
 }

--- a/tests/ArrayObjectTest.php
+++ b/tests/ArrayObjectTest.php
@@ -106,5 +106,13 @@ class ArrayObjectTest extends BaseTest
         $arrayObject = new Unsplash\ArrayObject([], $headers);
 
         $this->assertEquals(265, $arrayObject->currentPage());
+	}
+	
+    public function testRateLimitRemaining()
+    {
+        $headers = ['X-Ratelimit-Remaining' => ['10']];
+        $arrayObject = new Unsplash\ArrayObject([], $headers);
+
+        $this->assertEquals(10, $arrayObject->rateLimitRemaining());
     }
 }

--- a/tests/EndpointTest.php
+++ b/tests/EndpointTest.php
@@ -65,4 +65,14 @@ class EndpointTest extends BaseTest
         Unsplash\Endpoint::__callStatic('get', ['categories/3', []]);
         VCR::eject();
     }
+
+    public function testRateLimitResponseExists()
+    {
+        VCR::insertCassette('endpoint.yml');
+        $res = Unsplash\Endpoint::__callStatic('get', ['categories/2', []]);
+		VCR::eject();
+		$headers = $res->getHeaders();
+
+		$this->assertEquals('4984', $headers['X-RateLimit-Remaining'][0]);
+    }
 }

--- a/tests/EndpointTest.php
+++ b/tests/EndpointTest.php
@@ -70,9 +70,9 @@ class EndpointTest extends BaseTest
     {
         VCR::insertCassette('endpoint.yml');
         $res = Unsplash\Endpoint::__callStatic('get', ['categories/2', []]);
-		VCR::eject();
-		$headers = $res->getHeaders();
+        VCR::eject();
+        $headers = $res->getHeaders();
 
-		$this->assertEquals('4984', $headers['X-RateLimit-Remaining'][0]);
+        $this->assertEquals('4984', $headers['X-RateLimit-Remaining'][0]);
     }
 }


### PR DESCRIPTION
Without this exposed you could do something like this:

```php
$response = Crew\Unsplash\Photo::all();

$headers = (new ReflectionObject($response))->getProperty('headers');
$headers->setAccessible(true);
$headers = $headers->getValue($response);

if (intval($headers['X-Ratelimit-Remaining'][0]) < 500) send_message_to_slack();
```