### PR TITLE
Add Accept-Encoding: gzip header to all requests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.5.1 - 2020-04-07
+### Added
+- Added `Accept-Encoding: gzip` to requests.
+
 ## 2.5.0 - 2019-08-14
 ### Added
 - `toArray` method added to `ArrayObject` and `Endpoint`. https://github.com/unsplash/unsplash-php/pull/102/

--- a/src/HttpClient.php
+++ b/src/HttpClient.php
@@ -142,8 +142,12 @@ class HttpClient
             $uri = '/' . $uri;
         }
 
+        $headers = [
+            "Accept-Encoding" => "gzip"
+        ];
+
         $response = $this->httpClient->send(
-            new Request($method, new Uri($uri)),
+            new Request($method, new Uri($uri), $headers),
             $params
         );
 
@@ -169,7 +173,7 @@ class HttpClient
         $stack->push(Middleware::mapRequest(function (Request $request) {
                 return $request->withHeader('Authorization', $this->authorization);
         }), 'set_authorization_header');
-        
+
         // Set the request ui
         $stack->push(Middleware::mapRequest(function (Request $request) {
             $uri = $request->getUri()->withHost($this->host)->withScheme($this->scheme);


### PR DESCRIPTION
API supports it. Guzzle supports it. Why not support it together? 👯‍♀️