### PR TITLE
Be less specific on Guzzle version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
   ],
   "require": {
     "php": ">=7.3.0",
-    "guzzlehttp/guzzle": "^6.3.0|^7.0.1",
+    "guzzlehttp/guzzle": "^6.3.0|^7.0",
     "league/oauth2-client": ">=1.4.2",
     "hughbertd/oauth2-unsplash": ">=1.0.3"
 


### PR DESCRIPTION
Guzzle 7 is required by a lot of other packages, by being less specific it lets the systems that use multiple packages that use Guzzle to be able to install a common version