### PR TITLE
fix: Address deprecation warning in PHP 8.1

### DIFF
--- a/src/Endpoint.php
+++ b/src/Endpoint.php
@@ -181,6 +181,10 @@ class Endpoint
         ]);
 
         array_walk_recursive($parameters, function (&$link) use ($queryString) {
+            
+            if ($link === null) {
+                return;
+            }
 
             $parsedUrl = parse_url($link);
 


### PR DESCRIPTION
Addresses a deprecation warning in PHP 8.1 - filter out `null` link values before putting them through `parse_url`.

Resolves #125