### PR TITLE
feat: added 'lang' parameter to photos search

### DIFF
--- a/src/Search.php
+++ b/src/Search.php
@@ -26,7 +26,7 @@ class Search extends Endpoint
      * @return PageResult
      */
     public static function photos($search, $page = 1, $per_page = 10, $orientation = null, $collections = null,
-                                  $order_by = null, $content_filter = "low", $color = null)
+                                  $order_by = null, $content_filter = "low", $color = null, $lang = null)
     {
         $query = [
             'query' => $search,
@@ -52,6 +52,10 @@ class Search extends Endpoint
 
         if ( ! empty($color)) {
             $query['color'] = $color;
+        }
+
+        if ( ! empty($lang)) {
+            $query['lang'] = $lang;
         }
 
         $photos = self::get(

--- a/src/Search.php
+++ b/src/Search.php
@@ -23,6 +23,8 @@ class Search extends Endpoint
      * @param  string  $content_filter Limit results by content safety. (Optional; default: low). Valid values are low and high.
      * @param  string  $color        Filter results by color. Optional. Valid values are: black_and_white, black, white,
      *                               yellow, orange, red, purple, magenta, green, teal, and blue.
+     * @param  string  $lang         Search language code. Optional. Valid values here:
+     *                               https://unsplash.com/documentation#supported-languages
      * @return PageResult
      */
     public static function photos($search, $page = 1, $per_page = 10, $orientation = null, $collections = null,


### PR DESCRIPTION
This PR adds support for the beta parameter ['lang'](https://unsplash.com/documentation#parameters-16:~:text=Description-,lang,-Supported%20ISO%20639) on the [Search photos endpoint](https://unsplash.com/documentation#search).