### PR TITLE
Fix PHP 8.2: Creation of dynamic property Unsplash\ArrayObject::$page…

### DIFF
--- a/src/ArrayObject.php
+++ b/src/ArrayObject.php
@@ -19,6 +19,11 @@ class ArrayObject extends \ArrayObject
     private $pages = [];
 
     /**
+     * @var bool
+     */
+    private $pagesProcessed = false;
+
+    /**
      * @var array
      */
     private $basePages = [


### PR DESCRIPTION
As of PHP 8.2 the dynamic creation of properties results in a deprecation message:

> Creation of dynamic property Unsplash\ArrayObject::$pagesProcessed is deprecated in <b>unsplash/unsplash/src/ArrayObject.php on line 148

This PR fixes that by declaring the $pagesProcessed property.